### PR TITLE
Unlimit remote media count

### DIFF
--- a/app/javascript/flavours/glitch/components/media_gallery.jsx
+++ b/app/javascript/flavours/glitch/components/media_gallery.jsx
@@ -39,6 +39,14 @@ const messages = defineMessages({
   },
 });
 
+const colCount = function(size) {
+  return Math.max(Math.floor(Math.sqrt(size)), 2);
+};
+
+const rowCount = function(size) {
+  return Math.ceil(size / colCount(size));
+};
+
 class Item extends PureComponent {
 
   static propTypes = {
@@ -111,14 +119,18 @@ class Item extends PureComponent {
     let badges = [], thumbnail;
 
     let width  = 50;
-    let height = 100;
+    let height = 50;
 
-    if (size === 1) {
+    const cols = colCount(size);
+    const remaining = (-size % cols + cols) % cols;
+    const largeCount = Math.floor(remaining / 3); // width=2, height=2
+    const mediumCount = remaining % 3; // height=2
+
+    if (size === 1 || index < largeCount) {
       width = 100;
-    }
-
-    if (size === 4 || (size === 3 && index > 0)) {
-      height = 50;
+      height = 100;
+    } else if (size === 2 || index < largeCount + mediumCount) {
+      height = 100;
     }
 
     if (attachment.get('description')?.length > 0) {
@@ -329,7 +341,7 @@ class MediaGallery extends PureComponent {
   render () {
     const { media, lang, intl, sensitive, letterbox, fullwidth, defaultWidth, autoplay } = this.props;
     const { visible } = this.state;
-    const size     = media.take(4).size;
+    const size     = media.size;
     const uncached = media.every(attachment => attachment.get('type') === 'unknown');
 
     const width = this.state.width || defaultWidth;
@@ -343,13 +355,18 @@ class MediaGallery extends PureComponent {
     if (this.isStandaloneEligible()) { // TODO: cropImages setting
       style.aspectRatio = `${this.props.media.getIn([0, 'meta', 'small', 'aspect'])}`;
     } else {
+      const cols = colCount(media.size);
+      const rows = rowCount(media.size);
+      style.gridTemplateColumns = `repeat(${cols}, 1fr)`;
+      style.gridTemplateRows = `repeat(${rows}, 1fr)`;
+
       style.aspectRatio = '16 / 9';
     }
 
     if (this.isStandaloneEligible()) {
       children = <Item standalone autoplay={autoplay} onClick={this.handleClick} attachment={media.get(0)} lang={lang} displayWidth={width} visible={visible} />;
     } else {
-      children = media.take(4).map((attachment, i) => <Item key={attachment.get('id')} autoplay={autoplay} onClick={this.handleClick} attachment={attachment} index={i} lang={lang} size={size} letterbox={letterbox} displayWidth={width} visible={visible || uncached} />);
+      children = media.map((attachment, i) => <Item key={attachment.get('id')} autoplay={autoplay} onClick={this.handleClick} attachment={attachment} index={i} lang={lang} size={size} letterbox={letterbox} displayWidth={width} visible={visible || uncached} />);
     }
 
     if (uncached) {

--- a/app/javascript/mastodon/components/media_gallery.jsx
+++ b/app/javascript/mastodon/components/media_gallery.jsx
@@ -21,6 +21,14 @@ const messages = defineMessages({
   toggle_visible: { id: 'media_gallery.toggle_visible', defaultMessage: '{number, plural, one {Hide image} other {Hide images}}' },
 });
 
+const colCount = function(size) {
+  return Math.floor(Math.sqrt(size));
+};
+
+const rowCount = function(size) {
+  return Math.ceil(size / colCount(size));
+};
+
 class Item extends PureComponent {
 
   static propTypes = {
@@ -92,14 +100,22 @@ class Item extends PureComponent {
     let badges = [], thumbnail;
 
     let width  = 50;
-    let height = 100;
+    let height = 50;
 
-    if (size === 1) {
+    const cols = colCount(size);
+    const remaining = (-size % cols + cols) % cols;
+
+    if (remaining === 3 && index === 0) {
       width = 100;
-    }
-
-    if (size === 4 || (size === 3 && index > 0)) {
-      height = 50;
+      height = 100;
+    } else if (remaining === 2 && index < 2) {
+      if (cols >= 4) {
+        width = 100;
+      } else {
+        height = 100;
+      }
+    } else if (remaining === 1 && index === 0) {
+      width  = 100;
     }
 
     if (attachment.get('description')?.length > 0) {
@@ -302,16 +318,21 @@ class MediaGallery extends PureComponent {
     if (this.isFullSizeEligible()) {
       style.aspectRatio = `${this.props.media.getIn([0, 'meta', 'small', 'aspect'])}`;
     } else {
-      style.aspectRatio = '3 / 2';
+      const cols = colCount(media.size);
+      const rows = rowCount(media.size);
+      style.gridTemplateColumns = `repeat(${cols}, 1fr)`;
+      style.gridTemplateRows = `repeat(${rows}, 1fr)`;
+
+      style.aspectRatio = `${3 * cols} / ${2 * rows}`;
     }
 
-    const size     = media.take(4).size;
+    const size     = media.size;
     const uncached = media.every(attachment => attachment.get('type') === 'unknown');
 
     if (this.isFullSizeEligible()) {
       children = <Item standalone autoplay={autoplay} onClick={this.handleClick} attachment={media.get(0)} lang={lang} displayWidth={width} visible={visible} />;
     } else {
-      children = media.take(4).map((attachment, i) => <Item key={attachment.get('id')} autoplay={autoplay} onClick={this.handleClick} attachment={attachment} index={i} lang={lang} size={size} displayWidth={width} visible={visible || uncached} />);
+      children = media.map((attachment, i) => <Item key={attachment.get('id')} autoplay={autoplay} onClick={this.handleClick} attachment={attachment} index={i} lang={lang} size={size} displayWidth={width} visible={visible || uncached} />);
     }
 
     if (uncached) {

--- a/app/javascript/mastodon/components/media_gallery.jsx
+++ b/app/javascript/mastodon/components/media_gallery.jsx
@@ -314,16 +314,12 @@ class MediaGallery extends PureComponent {
     if (this.isFullSizeEligible()) {
       style.aspectRatio = `${this.props.media.getIn([0, 'meta', 'small', 'aspect'])}`;
     } else {
-      if (media.size > 4) {
-        const cols = colCount(media.size);
-        const rows = rowCount(media.size);
-        style.gridTemplateColumns = `repeat(${cols}, 1fr)`;
-        style.gridTemplateRows = `repeat(${rows}, 1fr)`;
+      const cols = colCount(media.size);
+      const rows = rowCount(media.size);
+      style.gridTemplateColumns = `repeat(${cols}, 1fr)`;
+      style.gridTemplateRows = `repeat(${rows}, 1fr)`;
 
-        style.aspectRatio = `${3 * cols} / ${2 * rows}`;
-      } else {
-        style.aspectRatio = '3 / 2';
-      }
+      style.aspectRatio = '3 / 2';
     }
 
     const size     = media.size;

--- a/app/javascript/mastodon/components/media_gallery.jsx
+++ b/app/javascript/mastodon/components/media_gallery.jsx
@@ -104,23 +104,13 @@ class Item extends PureComponent {
 
     const cols = colCount(size);
     const remaining = (-size % cols + cols) % cols;
+    const largeCount = Math.floor(remaining / 3); // width=2, height=2
+    const mediumCount = remaining % 3; // height=2
 
-    if (remaining === 3 && index === 0 || size === 1) {
+    if (size === 1 || index < largeCount) {
       width = 100;
       height = 100;
-    } else if (remaining === 2 && index < 2) {
-      if (cols >= 4) {
-        width = 100;
-      } else {
-        height = 100;
-      }
-    } else if (remaining === 1 && index === 0) {
-      if (size === 3) {
-        height = 100;
-      } else {
-        width  = 100;
-      }
-    } else if (size === 2) {
+    } else if (size === 2 || index < largeCount + mediumCount) {
       height = 100;
     }
 

--- a/app/javascript/mastodon/components/media_gallery.jsx
+++ b/app/javascript/mastodon/components/media_gallery.jsx
@@ -22,7 +22,7 @@ const messages = defineMessages({
 });
 
 const colCount = function(size) {
-  return Math.floor(Math.sqrt(size));
+  return Math.max(Math.floor(Math.sqrt(size)), 2);
 };
 
 const rowCount = function(size) {
@@ -105,7 +105,7 @@ class Item extends PureComponent {
     const cols = colCount(size);
     const remaining = (-size % cols + cols) % cols;
 
-    if (remaining === 3 && index === 0) {
+    if (remaining === 3 && index === 0 || size === 1) {
       width = 100;
       height = 100;
     } else if (remaining === 2 && index < 2) {
@@ -115,7 +115,13 @@ class Item extends PureComponent {
         height = 100;
       }
     } else if (remaining === 1 && index === 0) {
-      width  = 100;
+      if (size === 3) {
+        height = 100;
+      } else {
+        width  = 100;
+      }
+    } else if (size === 2) {
+      height = 100;
     }
 
     if (attachment.get('description')?.length > 0) {
@@ -318,12 +324,16 @@ class MediaGallery extends PureComponent {
     if (this.isFullSizeEligible()) {
       style.aspectRatio = `${this.props.media.getIn([0, 'meta', 'small', 'aspect'])}`;
     } else {
-      const cols = colCount(media.size);
-      const rows = rowCount(media.size);
-      style.gridTemplateColumns = `repeat(${cols}, 1fr)`;
-      style.gridTemplateRows = `repeat(${rows}, 1fr)`;
+      if (media.size > 4) {
+        const cols = colCount(media.size);
+        const rows = rowCount(media.size);
+        style.gridTemplateColumns = `repeat(${cols}, 1fr)`;
+        style.gridTemplateRows = `repeat(${rows}, 1fr)`;
 
-      style.aspectRatio = `${3 * cols} / ${2 * rows}`;
+        style.aspectRatio = `${3 * cols} / ${2 * rows}`;
+      } else {
+        style.aspectRatio = '3 / 2';
+      }
     }
 
     const size     = media.size;

--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -125,7 +125,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
       visibility: @status_parser.visibility,
       thread: replied_to_status,
       conversation: conversation_from_uri(@object['conversation']),
-      media_attachment_ids: process_attachments.take(4).map(&:id),
+      media_attachment_ids: process_attachments.map(&:id),
       poll: process_poll,
     }
   end
@@ -257,7 +257,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
     as_array(@object['attachment']).each do |attachment|
       media_attachment_parser = ActivityPub::Parser::MediaAttachmentParser.new(attachment)
 
-      next if media_attachment_parser.remote_url.blank? || media_attachments.size >= 4
+      next if media_attachment_parser.remote_url.blank?
 
       begin
         media_attachment = MediaAttachment.create(

--- a/app/services/activitypub/process_status_update_service.rb
+++ b/app/services/activitypub/process_status_update_service.rb
@@ -73,7 +73,7 @@ class ActivityPub::ProcessStatusUpdateService < BaseService
     as_array(@json['attachment']).each do |attachment|
       media_attachment_parser = ActivityPub::Parser::MediaAttachmentParser.new(attachment)
 
-      next if media_attachment_parser.remote_url.blank? || @next_media_attachments.size > 4
+      next if media_attachment_parser.remote_url.blank?
 
       begin
         media_attachment   = previous_media_attachments.find { |previous_media_attachment| previous_media_attachment.remote_url == media_attachment_parser.remote_url }


### PR DESCRIPTION
- [x] Retreive remote media even if media count is > 4
- [x] Show media gallery for >4 media
- [ ] Remove grid related css from components.scss
- [x] Glitch flavour

10 media:
![image](https://github.com/tribela/mastodon/assets/5047683/7e55e7bc-839e-4bb7-b932-ae09638eebe9)
6 media:
![image](https://github.com/tribela/mastodon/assets/5047683/63521bd1-99e7-407b-b742-5b6fd892b1e1)

for <= 4 media, renders same as upstream does